### PR TITLE
Corrections to datadelay

### DIFF
--- a/R/estimate_reporting.R
+++ b/R/estimate_reporting.R
@@ -8,6 +8,7 @@
 #' estimate and the delay-adjusted severity estimate
 #'
 #' @inheritParams estimate_time_varying
+#' @inheritParams estimate_static
 #'
 #' @param type A string, either `"static"` or `"varying"` which determines
 #' whether [estimate_static()] or [estimate_time_varying()] is used to calculate

--- a/R/estimate_severity.R
+++ b/R/estimate_severity.R
@@ -15,7 +15,6 @@
 estimate_severity <- function(df_in,
                               poisson_threshold = 100,
                               location) {
-
   # transferring from data.frame to vector format, to tidy up the slightly messy
   # likelihood calculation
   total_cases <- unique(df_in$total_cases)

--- a/R/estimate_severity.R
+++ b/R/estimate_severity.R
@@ -6,26 +6,15 @@
 #' standard (naive) severity definition. We use a binomial likelihood,
 #' approximated by a Poisson likelihood for large samples
 #'
-#' @param total_cases The total number of cases observed over the period of an
-#' outbreak of interest. The total number of cases must be greater than or equal
-#' to the total number of deaths
-#'
-#' @param total_deaths The total number of deaths observed over the period of an
-#' outbreak of interest. The total number of deaths must be less than or equal
-#' to the total number of cases
-#'
-#' @param u_t The proportion of cases to cases with known outcomes up to the
-#' point of an outbreak of interest. Used to correct the total number of deaths
-#' for delays between case detection and outcome. Given that it is a proportion,
-#' it must be between 0.0 and 1.0.
+#' @inheritParams estimate_static
 #' @keywords internal
-#' @return A named vector with the MLE and 95% confidence interval of the
+#' @return A data.frame with the MLE and 95% confidence interval of the
 #' corrected severity estimates, named "severity_me", "severity_low", and
 #' "severity_high".
 #'
 estimate_severity <- function(df_in,
                               poisson_threshold = 100,
-                              group_by = "country") {
+                              location) {
 
   # transferring from data.frame to vector format, to tidy up the slightly messy
   # likelihood calculation
@@ -58,9 +47,9 @@ estimate_severity <- function(df_in,
   # 95% range of likelihood
   severity_lims <- range(pprange[lik >= (max(lik) - 1.92)])
 
-  if (group_by %in% colnames(df_in)) {
+  if (!is.null(location) && location %in% colnames(df_in)) {
     severity_estimate <- data.frame(
-      "location" = unique(df_in[[group_by]]),
+      "location" = unique(df_in[[location]]),
       "severity_me" = severity_me,
       "severity_lo" = severity_lims[[1]],
       "severity_hi" = severity_lims[[2]]

--- a/R/estimate_static.R
+++ b/R/estimate_static.R
@@ -82,7 +82,6 @@ estimate_static <- function(df_in,
                             epi_dist,
                             poisson_threshold = 100,
                             location) {
-
   # input checking
   checkmate::assert_data_frame(df_in)
   checkmate::assert_logical(correct_for_delays, len = 1L)

--- a/R/estimate_time_varying.R
+++ b/R/estimate_time_varying.R
@@ -158,7 +158,6 @@ estimate_time_varying <- function(df_in,
 
   #### Get severity estimates ####
   for (i in indices) {
-
     # handle case where deaths are fewer than non-zero known outcomes
     if (df_in$deaths[i] <= df_in$known_outcomes[i] &&
       isTRUE(df_in$known_outcomes[i] > 0)) {

--- a/R/format_output.R
+++ b/R/format_output.R
@@ -42,7 +42,7 @@
 #' ncfr <- estimate_static(
 #'   df_in = df_ebola_subset,
 #'   correct_for_delays = FALSE,
-#'   group_by = "location"
+#'   location = "location"
 #' )
 #'
 #' # Calculate static corrected CFRs
@@ -50,7 +50,7 @@
 #'   df_in = ebola1976,
 #'   correct_for_delays = TRUE,
 #'   epi_dist = onset_to_death_ebola,
-#'   group_by = "location"
+#'   location = "location"
 #' )
 #'
 #' # Formats the output of the CFR data.frames nicely
@@ -67,8 +67,15 @@ format_output <- function(df_in,
       (estimate_type %in% c("severity", "reporting"))
   )
 
+  # assign location vector
+  if ("location" %in% colnames(df_in)) {
+    vec_location <- df_in[["location"]]
+  } else {
+    vec_location <- NA_character_
+  }
+
   df_out <- data.frame(
-    "Location" = df_in[["location"]],
+    "Location" = vec_location,
     "Estimate" =
       sprintf(
         "%.2f%% (95%% CI: %.2f%% - %.2f%%)",
@@ -79,9 +86,12 @@ format_output <- function(df_in,
     stringsAsFactors = FALSE
   )
 
+
+
   if (!is.null(type)) {
     df_out$Type <- type
   }
 
-  return(df_out)
+  # return data frame
+  df_out
 }

--- a/R/known_outcomes.R
+++ b/R/known_outcomes.R
@@ -77,7 +77,6 @@ known_outcomes <- function(df_in,
 
   # main calculation loop
   for (i in case_length:1) {
-
     # Delay probability mass function, evaluated at times
     # within the case and death times series
     delay_pmf_eval <- pmf_vals[case_times[1:i]]

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,6 +19,8 @@ knitr::opts_chunk$set(
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![R-CMD-check](https://github.com/epiverse-trace/datadelay/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/epiverse-trace/datadelay/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://codecov.io/gh/epiverse-trace/datadelay/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/datadelay?branch=main)
+[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![CRAN status](https://www.r-pkg.org/badges/version/datadelay)](https://CRAN.R-project.org/package=datadelay)
 <!-- badges: end -->
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -49,6 +49,9 @@ library(datadelay)
 # Load the Ebola 1976 data provided with the package
 data("ebola1976")
 
+# assign a location
+ebola1976$location <- "DRC"
+
 # read epidist for EVD onset to death from {epiparameter}
 # accesses parameters reported in https://doi.org/10.1016/S0140-6736(18)31387-4
 onset_to_death_ebola <- epiparameter::epidist_db(
@@ -58,27 +61,43 @@ onset_to_death_ebola <- epiparameter::epidist_db(
 )
 
 # Calculate the static naive and corrected CFRs
-ncfr <- static_cfr(ebola1976, correct_for_delays = FALSE)
-ccfr <- static_cfr(ebola1976, correct_for_delays = TRUE, onset_to_death_ebola)
+ncfr <- estimate_static(
+  df_in = ebola1976, correct_for_delays = FALSE, location = "location"
+)
+ccfr <- estimate_static(
+  df_in = ebola1976,
+  correct_for_delays = TRUE,
+  epi_dist = onset_to_death_ebola,
+  location = "location"
+)
 
 # Print nicely formatted case fatality rate estimates
-format_cfr_neatly(ncfr)
-format_cfr_neatly(ccfr)
+format_output(ncfr, estimate_type = "severity")
+format_output(ccfr, estimate_type = "severity")
 ```
 
 Calculate and plot real-time CFR estimates up to a given point in time
 
 ```{r example-ebola-plot}
 # Calculate naive and corrected static CFRs up to a given point in time
-df_ncfr <- rolling_cfr(ebola1976, correct_for_delays = FALSE)
-df_ccfr <- rolling_cfr(
-  ebola1976,
-  correct_for_delays = TRUE,
-  onset_to_death_ebola
+df_ncfr <- estimate_time_varying(
+  df_in = ebola1976, correct_for_delays = FALSE,
+  burn_in_value = 7
 )
 
+df_ccfr <- estimate_time_varying(
+  ebola1976,
+  correct_for_delays = TRUE,
+  epi_dist = onset_to_death_ebola,
+  burn_in_value = 7
+)
+
+# plot case and death data
+plot_case_data(df_ccfr)
+plot_death_data(df_ccfr)
+
 # Plotting case and death data along with CFRs
-plot_data_and_cfr(df_ncfr, df_ccfr)
+plot_time_varying(df_ncfr, lower = 0, upper = 100)
 ```
 
 This package is currently a *concept*, as defined by the [RECON software

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/
 [![R-CMD-check](https://github.com/epiverse-trace/datadelay/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/epiverse-trace/datadelay/actions/workflows/R-CMD-check.yaml)
 [![Codecov test
 coverage](https://codecov.io/gh/epiverse-trace/datadelay/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/datadelay?branch=main)
+[![Lifecycle:
+experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![Project Status: WIP – Initial development is in progress, but there
+has not yet been a stable, usable release suitable for the
+public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/datadelay)](https://CRAN.R-project.org/package=datadelay)
 <!-- badges: end -->

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ library(datadelay)
 # Load the Ebola 1976 data provided with the package
 data("ebola1976")
 
+# assign a location
+ebola1976$location <- "DRC"
+
 # read epidist for EVD onset to death from {epiparameter}
 # accesses parameters reported in https://doi.org/10.1016/S0140-6736(18)31387-4
 onset_to_death_ebola <- epiparameter::epidist_db(
@@ -52,35 +55,64 @@ onset_to_death_ebola <- epiparameter::epidist_db(
   epi_dist = "onset_to_death",
   author = "Barry_etal"
 )
+#> Using Barry et al. (2018) <10.1016/S0140-6736(18)31387-4> PMID: 30047375. 
+#> To retrieve the short citation use the 'get_citation' function
 
 # Calculate the static naive and corrected CFRs
-ncfr <- static_cfr(ebola1976, correct_for_delays = FALSE)
-ccfr <- static_cfr(ebola1976, correct_for_delays = TRUE, onset_to_death_ebola)
+ncfr <- estimate_static(
+  df_in = ebola1976, correct_for_delays = FALSE, location = "location"
+)
+ccfr <- estimate_static(
+  df_in = ebola1976,
+  correct_for_delays = TRUE,
+  epi_dist = onset_to_death_ebola,
+  location = "location"
+)
 
 # Print nicely formatted case fatality rate estimates
-format_cfr_neatly(ncfr)
-#> [1] "CFR: 0.96% (95% CI: 0.92% - 0.98%)"
-format_cfr_neatly(ccfr)
-#> [1] "CFR: 0.96% (95% CI: 0.84% - 1.00%)"
+format_output(ncfr, estimate_type = "severity")
+#>   Location                         Estimate
+#> 1      DRC 95.51% (95% CI: 92.11% - 97.74%)
+format_output(ccfr, estimate_type = "severity")
+#>   Location                          Estimate
+#> 1      DRC 95.90% (95% CI: 84.20% - 100.00%)
 ```
 
 Calculate and plot real-time CFR estimates up to a given point in time
 
 ``` r
 # Calculate naive and corrected static CFRs up to a given point in time
-df_ncfr <- rolling_cfr(ebola1976, correct_for_delays = FALSE)
-df_ccfr <- rolling_cfr(
-  ebola1976,
-  correct_for_delays = TRUE,
-  onset_to_death_ebola
+df_ncfr <- estimate_time_varying(
+  df_in = ebola1976, correct_for_delays = FALSE,
+  burn_in_value = 7
 )
 
-# Plotting case and death data along with CFRs
-plot_data_and_cfr(df_ncfr, df_ccfr)
-#> Warning: Removed 1 row containing missing values (`geom_line()`).
+df_ccfr <- estimate_time_varying(
+  ebola1976,
+  correct_for_delays = TRUE,
+  epi_dist = onset_to_death_ebola,
+  burn_in_value = 7
+)
+
+# plot case and death data
+plot_case_data(df_ccfr)
 ```
 
 <img src="man/figures/README-example-ebola-plot-1.png" width="100%" />
+
+``` r
+plot_death_data(df_ccfr)
+```
+
+<img src="man/figures/README-example-ebola-plot-2.png" width="100%" />
+
+``` r
+
+# Plotting case and death data along with CFRs
+plot_time_varying(df_ncfr, lower = 0, upper = 100)
+```
+
+<img src="man/figures/README-example-ebola-plot-3.png" width="100%" />
 
 This package is currently a *concept*, as defined by the [RECON software
 lifecycle](https://www.reconverse.org/lifecycle.html). This means that

--- a/man/datadelay-package.Rd
+++ b/man/datadelay-package.Rd
@@ -12,6 +12,7 @@ Delay functions for routine surveillance data.
 Useful links:
 \itemize{
   \item \url{https://github.com/epiverse-trace/datadelay}
+  \item \url{https://epiverse-trace.github.io/datadelay/}
   \item Report bugs at \url{https://github.com/epiverse-trace/datadelay/issues}
 }
 

--- a/man/estimate_reporting.Rd
+++ b/man/estimate_reporting.Rd
@@ -13,7 +13,8 @@ estimate_reporting(
   burn_in_value = get_default_burn_in(epi_dist),
   smooth_inputs = NULL,
   correct_for_delays = NULL,
-  max_date = NULL
+  max_date = NULL,
+  location = "country"
 )
 }
 \arguments{
@@ -28,9 +29,9 @@ probability a case has a known outcomes (i.e. death) at time \eqn{t},
 parameterised with disease-specific parameters before it is supplied here.
 A typical example would be a symptom onset to death delay distribution.}
 
-\item{type}{A boolean flag which determines whether \code{\link[=estimate_static]{estimate_static()}} or
-\code{\link[=estimate_time_varying]{estimate_time_varying()}} is used to calculate the resulting ascertainment
-rate}
+\item{type}{A string, either \code{"static"} or \code{"varying"} which determines
+whether \code{\link[=estimate_static]{estimate_static()}} or \code{\link[=estimate_time_varying]{estimate_time_varying()}} is used to calculate
+the resulting ascertainment rate}
 
 \item{severity_baseline}{The assumed to be true baseline severity estimate
 used in the final ratio to estimate the overall ascertainment rate}
@@ -97,7 +98,8 @@ df_reporting_varying <- estimate_reporting(df_covid_uk,
   smooth_inputs = TRUE,
   burn_in_value = 7L,
   correct_for_delays = TRUE,
-  max_date = "2020-06-30"
+  max_date = "2020-06-30",
+  location = "U.K."
 )
 
 format_output(

--- a/man/estimate_reporting.Rd
+++ b/man/estimate_reporting.Rd
@@ -59,6 +59,10 @@ calculating a corrected severity}
 which the time-varying severity estimate will be calculated. Useful in the
 case of long time-series, where the user wishes to focus on a specific
 time-period}
+
+\item{location}{Column name as a string by which to disaggregate data for
+estimates. This is usually a column indicating the region or country to which
+the estimate applies.}
 }
 \value{
 A data.frame containing the MLE estimate and 95\% confidence interval

--- a/man/estimate_severity.Rd
+++ b/man/estimate_severity.Rd
@@ -4,24 +4,22 @@
 \alias{estimate_severity}
 \title{Estimate the corrected case fatality rate}
 \usage{
-estimate_severity(df_in, poisson_threshold = 100, group_by = "country")
+estimate_severity(df_in, poisson_threshold = 100, location)
 }
 \arguments{
-\item{total_cases}{The total number of cases observed over the period of an
-outbreak of interest. The total number of cases must be greater than or equal
-to the total number of deaths}
+\item{df_in}{A data.frame containing the outbreak data. A daily time series
+with dates or some other absolute indicator of time (e.g. epiday/epiweek) and
+the numbers of new cases and new deaths at each time point}
 
-\item{total_deaths}{The total number of deaths observed over the period of an
-outbreak of interest. The total number of deaths must be less than or equal
-to the total number of cases}
+\item{poisson_threshold}{The case count above which to use Poisson
+approximation. Set to 200 by default.}
 
-\item{u_t}{The proportion of cases to cases with known outcomes up to the
-point of an outbreak of interest. Used to correct the total number of deaths
-for delays between case detection and outcome. Given that it is a proportion,
-it must be between 0.0 and 1.0.}
+\item{location}{Column name as a string by which to disaggregate data for
+estimates. This is usually a column indicating the region or country to which
+the estimate applies.}
 }
 \value{
-A named vector with the MLE and 95\% confidence interval of the
+A data.frame with the MLE and 95\% confidence interval of the
 corrected severity estimates, named "severity_me", "severity_low", and
 "severity_high".
 }

--- a/man/estimate_static.Rd
+++ b/man/estimate_static.Rd
@@ -9,7 +9,7 @@ estimate_static(
   correct_for_delays = TRUE,
   epi_dist,
   poisson_threshold = 100,
-  group_by = NA
+  location
 )
 }
 \arguments{
@@ -32,11 +32,15 @@ A typical example would be a symptom onset to death delay distribution.}
 \item{poisson_threshold}{The case count above which to use Poisson
 approximation. Set to 200 by default.}
 
-\item{group_by}{Column name as a string by which to group data for estimates.}
+\item{location}{Column name as a string by which to disaggregate data for
+estimates. This is usually a column indicating the region or country to which
+the estimate applies.}
 }
 \value{
-A named vector with the MLE and 95\% confidence interval of the
-severity estimates, named "severity_me", "severity_low", and "severity_high".
+A data.frame with the MLE and 95\% confidence interval of the
+severity estimates, named "severity_me", "severity_low", and "severity_high",
+as well as a column "location" holding the grouping variable indicating the
+region.
 }
 \description{
 Calculates the severity of a disease, corrected for a
@@ -64,7 +68,7 @@ onset_to_death_ebola <- epidist_db(
 df_ncfr_static_ebola <- estimate_static(
   df_ebola_subset,
   correct_for_delays = FALSE,
-  group_by = "location"
+  location = "location"
 )
 
 format_output(
@@ -78,7 +82,7 @@ df_ccfr_static_ebola <- estimate_static(
   df_ebola_subset,
   correct_for_delays = TRUE,
   epi_dist = onset_to_death_ebola,
-  group_by = "location"
+  location = "location"
 )
 
 format_output(

--- a/man/format_output.Rd
+++ b/man/format_output.Rd
@@ -49,7 +49,7 @@ onset_to_death_ebola <- epiparameter::epidist_db(
 ncfr <- estimate_static(
   df_in = df_ebola_subset,
   correct_for_delays = FALSE,
-  group_by = "location"
+  location = "location"
 )
 
 # Calculate static corrected CFRs
@@ -57,7 +57,7 @@ ccfr <- estimate_static(
   df_in = ebola1976,
   correct_for_delays = TRUE,
   epi_dist = onset_to_death_ebola,
-  group_by = "location"
+  location = "location"
 )
 
 # Formats the output of the CFR data.frames nicely

--- a/vignettes/estimate_ascertainment.Rmd
+++ b/vignettes/estimate_ascertainment.Rmd
@@ -5,8 +5,10 @@ bibliography: resources/library.bib
 csl: resources/bmj.csl
 vignette: >
   %\VignetteIndexEntry{Estimating the proportion of cases that are reported during an outbreak}
-  %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
+  %\VignetteEngine{knitr::rmarkdown}
+editor_options: 
+  chunk_output_type: console
 ---
 
 <!-- removes the ugly border around the figures -->
@@ -102,8 +104,7 @@ proportion of cases, infections, hospitalisations --- or whichever proxy for
 infections is provide --- which have been ascertained. The method used within 
 this function extends the methods outlined in the previous vignettes about 
 estimating the severity during an ongoing outbreak and measuring how the 
-severity changes over time. Both methods are based on the Nishiura et 
-al.^[@nishiura2009early]^ methods to estimate severity. We extend this by 
+severity changes over time. Both methods are based on the @nishiura2009early methods to estimate severity. We extend this by 
 combining the resulting severity estimates with an assumed baseline severity 
 estimate. The proportion of cases, infections or other quantity provided that 
 have been ascertained is given by the ratio of the assumed to be true baseline 
@@ -182,13 +183,16 @@ We use the `estimate_reporting()` function within the `datadelay` package to
 calculate the time-varying CFR for the COVID-19 epidemic in the U.K:
 
 ```{r message = FALSE, warning = FALSE, eval = TRUE}
-df_reporting_static <- estimate_reporting(df_covid_uk_subset,
+df_reporting_static <- estimate_reporting(
+  df_covid_uk_subset,
   epi_dist = onset_to_death_covid,
   type = "static",
   severity_baseline = 0.014,
   correct_for_delays = TRUE
 ) |>
-  format_output(estimate_type = "reporting", type = "Under-reporting")
+  format_output(
+    estimate_type = "reporting", type = "Under-reporting"
+  )
 ```
 
 The function includes a `type` argument, which determines whether
@@ -207,9 +211,12 @@ df_reporting_varying <- estimate_reporting(df_covid_uk,
   smooth_inputs = TRUE,
   burn_in_value = 7,
   correct_for_delays = TRUE,
-  max_date = "2020-06-30"
+  max_date = "2020-06-30",
+  location = "country"
 ) |>
-  format_output(estimate_type = "reporting", type = "Under-reporting")
+  format_output(
+    estimate_type = "reporting", type = "Under-reporting"
+  )
 ```
 
 Once we have calculated both severity quantities over time, we plot the results.
@@ -263,8 +270,10 @@ df_reporting <- df_covid |>
   group_by(iso_code) |>
   mutate(total_deaths = max(deaths_total)) |>
   filter(total_deaths > 100000 & !is.na(country)) |>
-  filter(date < "2020-06-01") |>
-  group_map(~ estimate_reporting(
+  filter(date < "2020-06-01")
+
+df_reporting <-
+  group_map(df_reporting, ~ estimate_reporting(
     df_in = .,
     epi_dist = onset_to_death_covid,
     type = "varying",

--- a/vignettes/estimate_static_severity.Rmd
+++ b/vignettes/estimate_static_severity.Rmd
@@ -258,7 +258,7 @@ and corrected estimates using the following two commands (respectively):
 df_ncfr_static_ebola <- estimate_static(
   df_ebola_subset,
   correct_for_delays = FALSE,
-  group_by = "location"
+  location = "location"
 ) |>
   format_output(
     estimate_type = "severity",
@@ -270,7 +270,7 @@ df_ccfr_static_ebola <- estimate_static(
   df_ebola_subset,
   correct_for_delays = TRUE,
   epi_dist = onset_to_death_ebola,
-  group_by = "location"
+  location = "location"
 ) |>
   format_output(
     estimate_type = "severity",
@@ -378,7 +378,7 @@ the U.K:
 df_ncfr_static_covid <- estimate_static(
   df_covid_uk_subset,
   correct_for_delays = FALSE,
-  group_by = "country"
+  location = "country"
 ) |>
   format_output(
     estimate_type = "severity", type = "Naive CFR"
@@ -389,7 +389,7 @@ df_ccfr_static_covid <- estimate_static(
   df_covid_uk_subset,
   correct_for_delays = TRUE,
   epi_dist = onset_to_death_covid,
-  group_by = "country"
+  location = "country"
 ) |>
   format_output(estimate_type = "severity", type = "Corrected CFR")
 

--- a/vignettes/estimate_time_varying_severity.Rmd
+++ b/vignettes/estimate_time_varying_severity.Rmd
@@ -325,11 +325,12 @@ the following commands:
 df_covid_cfr |>
   ggplot(aes(x = date)) +
   geom_line(aes(y = severity_me), linetype = "dashed", alpha = 0.25) +
-  geom_ribbon(aes(
-    ymin = severity_lo,
-    ymax = severity_hi
-  ),
-  fill = "dodgerblue", alpha = 0.5
+  geom_ribbon(
+    aes(
+      ymin = severity_lo,
+      ymax = severity_hi
+    ),
+    fill = "dodgerblue", alpha = 0.5
   ) +
   coord_cartesian(clip = "off") +
   facet_wrap(~country, ncol = 2) +


### PR DESCRIPTION
This PR makes some emergency corrections prompted by issue #34:

1. The Readme has been corrected to use the functions currently exported and old functions have been removed, this fixes #35;
2. The Readme now has {lifecycle} and Repostatus badges, this fixes #34 
3. The functions `estimate_severity()` and `estimate_static()` have been edited for better functionality around the `location` column, and the argument name has been changed from `group_by` to `location` as well to avoid confusion with the function `dplyr::group_by()`, this fixes #36.